### PR TITLE
No common next protocol should fail handshake

### DIFF
--- a/npn-boot/src/main/java/sun/security/ssl/ClientHandshaker.java
+++ b/npn-boot/src/main/java/sun/security/ssl/ClientHandshaker.java
@@ -1413,13 +1413,18 @@ final class ClientHandshaker extends Handshaker {
             }
             else
             {
-                String protocol = ((NextProtoNego.ClientProvider)provider).selectProtocol(protocols);
-                if (NextProtoNego.debug)
-                    System.err.println(new StringBuilder("[C] NPN selected '").append(protocol).append("' for ").append(conn != null ? conn : engine));
-                if (protocol != null)
+                try
                 {
+                    String protocol = ((NextProtoNego.ClientProvider)provider).selectProtocol(protocols);
+                    if (NextProtoNego.debug)
+                        System.err.println(new StringBuilder("[C] NPN selected '").append(protocol).append("' for ").append(conn != null ? conn : engine));
                     new NextProtocolMessage(protocol).write(output);
                     output.flush();
+                }
+                catch(Throwable t)
+                {
+                    fatalSE(Alerts.alert_handshake_failure, "NPN protocol selection failure", t);
+                    return;
                 }
             }
         }

--- a/npn-boot/src/main/java/sun/security/ssl/NextProtocolMessage.java
+++ b/npn-boot/src/main/java/sun/security/ssl/NextProtocolMessage.java
@@ -19,7 +19,7 @@ package sun.security.ssl;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class NextProtocolMessage extends HandshakeMessage
 {
@@ -31,7 +31,7 @@ public class NextProtocolMessage extends HandshakeMessage
 
     public NextProtocolMessage(String protocol)
     {
-        protocolBytes = protocol.getBytes(Charset.forName("UTF-8"));
+        protocolBytes = protocol == null ? new byte[0] : protocol.getBytes(StandardCharsets.UTF_8);
         paddingBytes = new byte[32 - ((1 + protocolBytes.length + 1) % 32)];
         this.protocol = protocol;
     }
@@ -40,9 +40,13 @@ public class NextProtocolMessage extends HandshakeMessage
     {
         protocolBytes = input.getBytes8();
         paddingBytes = input.getBytes8();
-        protocol = new String(protocolBytes, "UTF-8");
+        protocol = protocolBytes.length == 0 ? null : new String(protocolBytes, StandardCharsets.UTF_8);
     }
 
+    /**
+     * Get the {@code selected_protocol} 
+     * @return The {@code selected_protocol}. May be {@code null}.
+     */
     public String getProtocol()
     {
         return protocol;

--- a/npn-boot/src/main/java/sun/security/ssl/ServerHandshaker.java
+++ b/npn-boot/src/main/java/sun/security/ssl/ServerHandshaker.java
@@ -1745,7 +1745,15 @@ final class ServerHandshaker extends Handshaker {
             String protocol = message.getProtocol();
             if (NextProtoNego.debug)
                 System.err.println(new StringBuilder("[S] NPN selected '").append(protocol).append("' for ").append(conn != null ? conn : engine));
-            provider.protocolSelected(protocol);
+            try
+            {
+                provider.protocolSelected(protocol);
+            }
+            catch (Throwable t)
+            {
+                fatalSE(Alerts.alert_handshake_failure, "NPN selected protocol not acceptable", t);
+                return;
+            }
         }
     }
     // NPN_CHANGES_END

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     </scm>
 
     <properties>
-        <npn-api-version>1.1.0.v20120525</npn-api-version>
+        <npn-api-version>1.1.1.v20141010</npn-api-version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Motiviation:
There is currently no means to fail the SSL handshake due to there being no common next protocol.
The current treatment of a  return value from  also results in no NextProtocolMessage being sent to the server.
According to [NPN RFC section 3](http://tools.ietf.org/html/draft-agl-tls-nextprotoneg-04#section-3) and [Google's NPN Spec, Next Protocol Negotiation Extension Section](https://technotes.googlecode.com/git/nextprotoneg.html)  if the server included a  extension.

Modifications:
-Returning  from  should result in a failed SSL handshake with alert no_application_protocol(120)
-Add unit test for this scenario

Result:
jetty npn-boot is compatible with specifications and allows a means to fail the handshake if no common next procotols found.
